### PR TITLE
Remove extra "WHERE" from getExample

### DIFF
--- a/Sources/ActivitiesService/Model/Activity/Activity+MySQLDataAccessor.swift
+++ b/Sources/ActivitiesService/Model/Activity/Activity+MySQLDataAccessor.swift
@@ -48,7 +48,7 @@ public class ActivityMySQLDataAccessor: ActivityMySQLDataAccessorProtocol {
     public func getExample(withID id: String) throws -> [Activity]? {
         let select = MySQLQueryBuilder()
                         .select(fields: ["name"], table: "activities")
-                        .wheres(statement:"WHERE Id=?", parameters: id)
+                        .wheres(statement:"Id=?", parameters: id)
 
         let result = try execute(builder: select)
         let activities = result.toActivities()


### PR DESCRIPTION
There was an unneeded "WHERE" being injected that created an invalid query when built.